### PR TITLE
Updated skill building platforms list with BotTalk

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -113,6 +113,7 @@
 * [PullString](https://www.pullstring.com) - Design, prototype, and publish voice apps for Amazon Alexa, Google Assistant and IoT devices.
 * [Conversable](http://conversable.com/) - Conversable is the enterprise conversational intelligence platform for creating intuitive, on-demand, automated experiences on any messaging or voice channel.
 * [kitt.ai](https://kitt.ai) - KITT.AI offers Conversational Understanding as a Service with ChatFlow and customizable wake word detection on embedded devices.
+* [BotTalk](https://bottalk.de) - BotTalk - Create Complex Alexa Skills with simple markup language. Session management, context awareness, third party APIs integration, template language support, automated tests of all possible dialog flows, one-click deploys.
 
 ### Tools
 


### PR DESCRIPTION
Changes proposed in this pull request

- Add BotTalk to the Alexa skill builders list
